### PR TITLE
improved lidar recovery

### DIFF
--- a/sdk/include/rplidar_driver.h
+++ b/sdk/include/rplidar_driver.h
@@ -2,26 +2,26 @@
  * Copyright (c) 2014, RoboPeak
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, 
+ * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice, 
- *    this list of conditions and the following disclaimer in the documentation 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
@@ -31,7 +31,7 @@
  *
  *  Copyright 2009 - 2014 RoboPeak Team
  *  http://www.robopeak.com
- * 
+ *
  */
 
 #pragma once
@@ -56,19 +56,19 @@ public:
     /// Create an RPLIDAR Driver Instance
     /// This interface should be invoked first before any other operations
     ///
-    /// \param drivertype the connection type used by the driver. 
+    /// \param drivertype the connection type used by the driver.
     static RPlidarDriver * CreateDriver(_u32 drivertype = DRIVER_TYPE_SERIALPORT);
 
     /// Dispose the RPLIDAR Driver Instance specified by the drv parameter
     /// Applications should invoke this interface when the driver instance is no longer used in order to free memory
-    static void DisposeDriver(RPlidarDriver * drv);
+    static void DisposeDriver(RPlidarDriver ** drv);
 
 
 public:
     /// Open the specified serial port and connect to a target RPLIDAR device
     ///
-    /// \param port_path     the device path of the serial port 
-    ///        e.g. on Windows, it may be com3 or \\.\com10 
+    /// \param port_path     the device path of the serial port
+    ///        e.g. on Windows, it may be com3 or \\.\com10
     ///             on Unix-Like OS, it may be /dev/ttyS1, /dev/ttyUSB2, etc
     ///
     /// \param baudrate      the baudrate used
@@ -88,7 +88,7 @@ public:
     /// Ask the RPLIDAR core system to reset it self
     /// The host system can use the Reset operation to help RPLIDAR escape the self-protection mode.
     ///
-    //  \param timeout       The operation timeout value (in millisecond) for the serial port communication                     
+    //  \param timeout       The operation timeout value (in millisecond) for the serial port communication
     virtual u_result reset(_u32 timeout = DEFAULT_TIMEOUT) = 0;
 
     /// Retrieve the health status of the RPLIDAR
@@ -96,14 +96,14 @@ public:
     ///
     /// \param health        The health status info returned from the RPLIDAR
     ///
-    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication     
+    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication
     virtual u_result getHealth(rplidar_response_device_health_t & health, _u32 timeout = DEFAULT_TIMEOUT) = 0;
 
     /// Get the device information of the RPLIDAR include the serial number, firmware version, device model etc.
-    /// 
+    ///
     /// \param info          The device information returned from the RPLIDAR
     ///
-    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication  
+    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication
     virtual u_result getDeviceInfo(rplidar_response_device_info_t & info, _u32 timeout = DEFAULT_TIMEOUT) = 0;
 
 
@@ -124,17 +124,17 @@ public:
     ///
     /// \param force         Force the core system to output scan data regardless whether the scanning motor is rotating or not.
     ///
-    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication 
+    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication
     virtual u_result startScan(bool force = false, _u32 timeout = DEFAULT_TIMEOUT) = 0;
 
 
     /// Ask the RPLIDAR core system to stop the current scan operation and enter idle state. The background thread will be terminated
     ///
-    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication 
+    /// \param timeout       The operation timeout value (in millisecond) for the serial port communication
     virtual u_result stop(_u32 timeout = DEFAULT_TIMEOUT) = 0;
 
 
-    /// Wait and grab a complete 0-360 degree scan data previously received. 
+    /// Wait and grab a complete 0-360 degree scan data previously received.
     /// The grabbed scan data returned by this interface always has the following charactistics:
     ///
     /// 1) The first node of the grabbed data array (nodebuffer[0]) must be the first sample of a scan, i.e. the start_bit == 1
@@ -148,7 +148,7 @@ public:
     ///
     /// \param timeout        Max duration allowed to wait for a complete scan data, nothing will be stored to the nodebuffer if a complete 360-degrees' scan data cannot to be ready timely.
     ///
-    /// The interface will return RESULT_OPERATION_TIMEOUT to indicate that no complete 360-degrees' scan can be retrieved withing the given timeout duration. 
+    /// The interface will return RESULT_OPERATION_TIMEOUT to indicate that no complete 360-degrees' scan can be retrieved withing the given timeout duration.
     ///
     /// \The caller application can set the timeout value to Zero(0) to make this interface always returns immediately to achieve non-block operation.
 	virtual u_result grabScanData(rplidar_response_measurement_node_t * nodebuffer, size_t & count, _u32 timeout = DEFAULT_TIMEOUT) = 0;
@@ -159,12 +159,12 @@ public:
     ///
     /// \param count          The caller must initialize this parameter to set the max data count of the provided buffer (in unit of rplidar_response_measurement_node_t).
     ///                       Once the interface returns, this parameter will store the actual received data count.
-    /// The interface will return RESULT_OPERATION_FAIL when all the scan data is invalid. 
+    /// The interface will return RESULT_OPERATION_FAIL when all the scan data is invalid.
     virtual u_result ascendScanData(rplidar_response_measurement_node_t * nodebuffer, size_t count) = 0;
 
 	virtual u_result stopMotor() = 0;
 	virtual u_result startMotor() = 0;
-	
+
 protected:
     RPlidarDriver() {}
     virtual ~RPlidarDriver() {}

--- a/sdk/src/rplidar_driver.cpp
+++ b/sdk/src/rplidar_driver.cpp
@@ -2,26 +2,26 @@
  * Copyright (c) 2014, RoboPeak
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, 
+ * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice, 
- *    this list of conditions and the following disclaimer in the documentation 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
@@ -31,7 +31,7 @@
  *
  *  Copyright 2009 - 2014 RoboPeak Team
  *  http://www.robopeak.com
- * 
+ *
  */
 
 #include "sdkcommon.h"
@@ -60,16 +60,17 @@ RPlidarDriver * RPlidarDriver::CreateDriver(_u32 drivertype)
 }
 
 
-void RPlidarDriver::DisposeDriver(RPlidarDriver * drv)
+void RPlidarDriver::DisposeDriver(RPlidarDriver ** drv)
 {
-    delete drv;
+  delete *drv;
+  *drv = NULL;
 }
 
 
 
 // Serial Driver Impl
 
-RPlidarDriverSerialImpl::RPlidarDriverSerialImpl() 
+RPlidarDriverSerialImpl::RPlidarDriverSerialImpl()
     : _isConnected(false)
     , _isScanning(false)
 {
@@ -127,9 +128,9 @@ u_result RPlidarDriverSerialImpl::reset(_u32 timeout)
 u_result RPlidarDriverSerialImpl::getHealth(rplidar_response_device_health_t & healthinfo, _u32 timeout)
 {
     u_result  ans;
-    
+
     if (!isConnected()) return RESULT_OPERATION_FAIL;
-    
+
     _disableDataGrabbing();
 
     {
@@ -163,7 +164,7 @@ u_result RPlidarDriverSerialImpl::getHealth(rplidar_response_device_health_t & h
 u_result RPlidarDriverSerialImpl::getDeviceInfo(rplidar_response_device_info_t & info, _u32 timeout)
 {
     u_result  ans;
-    
+
     if (!isConnected()) return RESULT_OPERATION_FAIL;
 
     _disableDataGrabbing();
@@ -279,8 +280,8 @@ u_result RPlidarDriverSerialImpl::_cacheScanData()
         {
             if (local_buf[pos].sync_quality & RPLIDAR_RESP_MEASUREMENT_SYNCBIT)
             {
-                // only publish the data when it contains a full 360 degree scan 
-                
+                // only publish the data when it contains a full 360 degree scan
+
                 if ((local_scan[0].sync_quality & RPLIDAR_RESP_MEASUREMENT_SYNCBIT)) {
                     _lock.lock();
                     memcpy(_cached_scan_node_buf, local_scan, scan_count*sizeof(rplidar_response_measurement_node_t));
@@ -379,7 +380,7 @@ u_result RPlidarDriverSerialImpl::ascendScanData(rplidar_response_measurement_no
             nodebuffer[i].angle_q6_checkbit = (((_u16)(expect_angle * 64.0f)) << RPLIDAR_RESP_MEASUREMENT_ANGLE_SHIFT) + checkbit;
         }
     }
-            
+
     // find zero_position in the full scan
     size_t zero_pos = 0;
     float pre_degree = (nodebuffer[0].angle_q6_checkbit >> RPLIDAR_RESP_MEASUREMENT_ANGLE_SHIFT)/64.0f;
@@ -435,13 +436,13 @@ u_result RPlidarDriverSerialImpl::_waitNode(rplidar_response_measurement_node_t 
         size_t recvSize;
 
         int ans = _rxtx->waitfordata(remainSize, timeout-waitTime, &recvSize);
-        if (ans == rp::hal::serial_rxtx::ANS_DEV_ERR) 
+        if (ans == rp::hal::serial_rxtx::ANS_DEV_ERR)
             return RESULT_OPERATION_FAIL;
         else if (ans == rp::hal::serial_rxtx::ANS_TIMEOUT)
             return RESULT_OPERATION_TIMEOUT;
 
         if (recvSize > remainSize) recvSize = remainSize;
-        
+
         _rxtx->recvdata(recvBuffer, recvSize);
 
         for (size_t pos = 0; pos < recvSize; ++pos) {
@@ -497,7 +498,7 @@ u_result RPlidarDriverSerialImpl::_waitScanData(rplidar_response_measurement_nod
         if (IS_FAIL(ans = _waitNode(&node, timeout - waitTime))) {
             return ans;
         }
-        
+
         nodebuffer[recvNodeCount++] = node;
 
         if (recvNodeCount == count) return RESULT_OK;
@@ -560,15 +561,15 @@ u_result RPlidarDriverSerialImpl::_waitResponseHeader(rplidar_ans_header_t * hea
     while ((waitTime=getms() - startTs) <= timeout) {
         size_t remainSize = sizeof(rplidar_ans_header_t) - recvPos;
         size_t recvSize;
-        
+
         int ans = _rxtx->waitfordata(remainSize, timeout - waitTime, &recvSize);
-        if (ans == rp::hal::serial_rxtx::ANS_DEV_ERR) 
+        if (ans == rp::hal::serial_rxtx::ANS_DEV_ERR)
             return RESULT_OPERATION_FAIL;
         else if (ans == rp::hal::serial_rxtx::ANS_TIMEOUT)
             return RESULT_OPERATION_TIMEOUT;
-        
+
         if(recvSize > remainSize) recvSize = remainSize;
-        
+
         _rxtx->recvdata(recvBuffer, recvSize);
 
         for (size_t pos = 0; pos < recvSize; ++pos) {
@@ -578,7 +579,7 @@ u_result RPlidarDriverSerialImpl::_waitResponseHeader(rplidar_ans_header_t * hea
                 if (currentByte != RPLIDAR_ANS_SYNC_BYTE1) {
                    continue;
                 }
-                
+
                 break;
             case 1:
                 if (currentByte != RPLIDAR_ANS_SYNC_BYTE2) {


### PR DESCRIPTION
- deletes left-over driver instance before initialising
- adds proper disposal of driver instances (pointer magic)
- resets scanning only if driver is healthy
