### PR TITLE
Check for data size for ensuring valid time_increment

### DIFF
--- a/src/rplidar_nodelet.cpp
+++ b/src/rplidar_nodelet.cpp
@@ -193,16 +193,19 @@ namespace rplidar_ros {
                          angle_min, angle_max,
                          frame_id);
            }
-        } else if (op_result == RESULT_OPERATION_FAIL) {
+      } else if (op_result == RESULT_OPERATION_FAIL) {
             // All the data is invalid, just publish them
             float angle_min = DEG2RAD(0.0f);
             float angle_max = DEG2RAD(359.0f);
+
+            NODELET_WARN_STREAM("RPLidar : Publishing Invalid data; might burst! watch out..");
 
             this->publish_scan(&scan_pub, nodes, count,
                          start_scan_time, scan_duration, inverted,
                          angle_min, angle_max,
                          frame_id);
         }
+
     }
     else if ( op_result == RESULT_OPERATION_TIMEOUT)
     {
@@ -267,6 +270,19 @@ namespace rplidar_ros {
           }
       }
 
+      // Check if the data size is not equal to 360. if not don't publish it
+      // This is strict check which could to lose to see only if node_count is 0
+      // But 99% of the time RPlidar produces 360 sized data
+      if (node_count != 360) {
+        NODELET_WARN_STREAM("RPLidar : Node count is not equal to 360");
+        NODELET_WARN_STREAM("Node Count: " << node_count);
+      }
+
+      if (scan_msg->time_increment == std::numeric_limits<float>::infinity()) {
+        NODELET_WARN_STREAM("RPLidar : Time increment is infinity!");
+        NODELET_WARN_STREAM("Node Count: " << node_count);
+      }
+      
       pub->publish(scan_msg);
   }
 
@@ -432,4 +448,3 @@ namespace rplidar_ros {
 } // namespace rplidar_ros
 
 PLUGINLIB_DECLARE_CLASS(rplidar_nodelet, RPlidarNodelet, rplidar_ros::RPlidarNodelet, nodelet::Nodelet);
-


### PR DESCRIPTION
The obvious reason I could figure out was:
`time_increment = scan_time / (double)(node_count-1)`

When `node_count` is `1`, the `time_increment` would be `inf`.

This also matches with the stack-trace in the reported issue where `scan_ranges.size()` is small which is also re-sized by `node_count`.

The other thing is even when the data is invalid, it was published by the driver:
`else if (op_result == RESULT_OPERATION_FAIL) {
    // All the data is invalid, just publish them
    this->publish_scan(...);
}`

which might be causing the above problem.
