### PR TITLE
Stop bad data

### DIFF
--- a/src/rplidar_nodelet.cpp
+++ b/src/rplidar_nodelet.cpp
@@ -193,19 +193,18 @@ namespace rplidar_ros {
                          angle_min, angle_max,
                          frame_id);
            }
-      }
-      // publishing invalid data may cause higher level programs to break
-      // so do not publish it
-      /*else if (op_result == RESULT_OPERATION_FAIL) {
+      } else if (op_result == RESULT_OPERATION_FAIL) {
             // All the data is invalid, just publish them
             float angle_min = DEG2RAD(0.0f);
             float angle_max = DEG2RAD(359.0f);
+
+            NODELET_WARN_STREAM("RPLidar : Publishing Invalid data; might burst! watch out..");
 
             this->publish_scan(&scan_pub, nodes, count,
                          start_scan_time, scan_duration, inverted,
                          angle_min, angle_max,
                          frame_id);
-        }*/
+        }
 
     }
     else if ( op_result == RESULT_OPERATION_TIMEOUT)
@@ -275,9 +274,16 @@ namespace rplidar_ros {
       // This is strict check which could to lose to see only if node_count is 0
       // But 99% of the time RPlidar produces 360 sized data
       if (node_count != 360) {
-          NODELET_INFO_STREAM("Node Count: " << node_count);
-          pub->publish(scan_msg);
+        NODELET_WARN_STREAM("RPLidar : Node count is not equal to 360");
+        NODELET_WARN_STREAM("Node Count: " << node_count);
       }
+
+      if (scan_msg->time_increment == std::numeric_limits<float>::infinity()) {
+        NODELET_WARN_STREAM("RPLidar : Time increment is infinity!");
+        NODELET_WARN_STREAM("Node Count: " << node_count);
+      }
+      
+      pub->publish(scan_msg);
   }
 
   int RPlidarNodelet::init_driver(std::string& serial_port, int& serial_baudrate)

--- a/src/rplidar_nodelet.cpp
+++ b/src/rplidar_nodelet.cpp
@@ -193,7 +193,10 @@ namespace rplidar_ros {
                          angle_min, angle_max,
                          frame_id);
            }
-        } else if (op_result == RESULT_OPERATION_FAIL) {
+      }
+      // publishing invalid data may cause higher level programs to break
+      // so do not publish it
+      /*else if (op_result == RESULT_OPERATION_FAIL) {
             // All the data is invalid, just publish them
             float angle_min = DEG2RAD(0.0f);
             float angle_max = DEG2RAD(359.0f);
@@ -202,7 +205,8 @@ namespace rplidar_ros {
                          start_scan_time, scan_duration, inverted,
                          angle_min, angle_max,
                          frame_id);
-        }
+        }*/
+
     }
     else if ( op_result == RESULT_OPERATION_TIMEOUT)
     {
@@ -267,7 +271,13 @@ namespace rplidar_ros {
           }
       }
 
-      pub->publish(scan_msg);
+      // Check if the data size is not equal to 360. if not don't publish it
+      // This is strict check which could to lose to see only if node_count is 0
+      // But 99% of the time RPlidar produces 360 sized data
+      if (node_count != 360) {
+          NODELET_INFO_STREAM("Node Count: " << node_count);
+          pub->publish(scan_msg);
+      }
   }
 
   int RPlidarNodelet::init_driver(std::string& serial_port, int& serial_baudrate)
@@ -432,4 +442,3 @@ namespace rplidar_ros {
 } // namespace rplidar_ros
 
 PLUGINLIB_DECLARE_CLASS(rplidar_nodelet, RPlidarNodelet, rplidar_ros::RPlidarNodelet, nodelet::Nodelet);
-

--- a/src/rplidar_nodelet.cpp
+++ b/src/rplidar_nodelet.cpp
@@ -194,7 +194,11 @@ namespace rplidar_ros {
                          frame_id);
            }
       } else if (op_result == RESULT_OPERATION_FAIL) {
-            // All the data is invalid, just publish them
+            // All the data is invalid
+            // SHOULD NOT PUBLISH ANY DATA FROM here
+            // BECAUSE IT CAN CRASH THE PROGRAMS USING THE DATA
+
+            /*
             float angle_min = DEG2RAD(0.0f);
             float angle_max = DEG2RAD(359.0f);
 
@@ -204,6 +208,7 @@ namespace rplidar_ros {
                          start_scan_time, scan_duration, inverted,
                          angle_min, angle_max,
                          frame_id);
+            */
         }
 
     }
@@ -273,17 +278,10 @@ namespace rplidar_ros {
       // Check if the data size is not equal to 360. if not don't publish it
       // This is strict check which could to lose to see only if node_count is 0
       // But 99% of the time RPlidar produces 360 sized data
-      if (node_count != 360) {
-        NODELET_WARN_STREAM("RPLidar : Node count is not equal to 360");
-        NODELET_WARN_STREAM("Node Count: " << node_count);
+      if (node_count == 360) {  // Only publish when data size is 360
+        pub->publish(scan_msg);
       }
 
-      if (scan_msg->time_increment == std::numeric_limits<float>::infinity()) {
-        NODELET_WARN_STREAM("RPLidar : Time increment is infinity!");
-        NODELET_WARN_STREAM("Node Count: " << node_count);
-      }
-      
-      pub->publish(scan_msg);
   }
 
   int RPlidarNodelet::init_driver(std::string& serial_port, int& serial_baudrate)


### PR DESCRIPTION
This commit ensures that data is only published when data size is 360.

This will cause:
- programs(transformToPointCloud) not to burst when data size is 1 and time_increment is inf.
- avoid publishing incomplete or corrupt data.
