### PR TITLE
diagnostics in rplidar_driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(catkin REQUIRED COMPONENTS
   nodelet
   pluginlib
   message_filters
+  diagnostic_msgs
+  diagnostic_updater
 )
 
 

--- a/include/rplidar_ros/rplidar_nodelet.hpp
+++ b/include/rplidar_ros/rplidar_nodelet.hpp
@@ -17,6 +17,9 @@
 
 #include "rplidar.h" //RPLIDAR standard sdk, all-in-one header
 
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <diagnostic_updater/publisher.h>
+
 
 using namespace rp::standalone::rplidar;
 
@@ -42,8 +45,7 @@ namespace rplidar_ros {
     bool start_motor(std_srvs::Empty::Request &req,std_srvs::Empty::Response &res);
     bool reset_device(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
     bool reset_scan(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
-
-
+    void device_diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);
 
     RPlidarNodelet(){};
     ~RPlidarNodelet(){};
@@ -61,6 +63,9 @@ namespace rplidar_ros {
     std::string serial_port;
     int serial_baudrate;
     int res;
+    int result_timeout_counter;
+    int result_fail_counter;
+    int bad_health_counter;
 
     boost::mutex mutex_;
     ros::Publisher scan_pub;
@@ -68,9 +73,11 @@ namespace rplidar_ros {
     ros::ServiceServer start_motor_service;
     ros::ServiceServer reset_device_service;
     ros::ServiceServer reset_scan_service;
+    ros::Time starting_time;
+    ros::Duration elapsed_time;
 
     boost::shared_ptr<boost::thread> device_thread_;
-
+    diagnostic_updater::Updater updater;
 
   };
 

--- a/include/rplidar_ros/rplidar_nodelet.hpp
+++ b/include/rplidar_ros/rplidar_nodelet.hpp
@@ -46,6 +46,7 @@ namespace rplidar_ros {
     bool reset_device(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
     bool reset_scan(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
     void device_diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);
+    void diagnosticsRatePoll();
 
     RPlidarNodelet(){};
     ~RPlidarNodelet(){};
@@ -61,11 +62,16 @@ namespace rplidar_ros {
     bool inverted;
     std::string frame_id;
     std::string serial_port;
+    int diagnostics_time_window;
     int serial_baudrate;
     int res;
     int result_timeout_counter;
     int result_fail_counter;
     int bad_health_counter;
+    std::deque<ros::Time> result_timeout_deque;
+    std::deque<ros::Time> result_fail_deque;
+    std::deque<ros::Time> bad_health_deque;
+    std::vector< std::deque<ros::Time> > rate_error_deques;
 
     boost::mutex mutex_;
     ros::Publisher scan_pub;
@@ -77,6 +83,7 @@ namespace rplidar_ros {
     ros::Duration elapsed_time;
 
     boost::shared_ptr<boost::thread> device_thread_;
+    boost::shared_ptr<boost::thread> diagnostics_rate_thread_;
     diagnostic_updater::Updater updater;
 
   };

--- a/launch/rplidar.launch
+++ b/launch/rplidar.launch
@@ -5,6 +5,7 @@
   <arg name="inverted"          default="false"/>
   <arg name="angle_compensate"  default="true"/>
   <arg name="topic_name"        default="scan"/>
+  <arg name="diag_time_window"  default="30"/>
 
   <node name="rplidar_node"          pkg="rplidar_ros"  type="rplidar_node" output="screen">
     <param name="serial_port"         type="string" value="$(arg serial_port)"/>
@@ -12,6 +13,7 @@
     <param name="frame_id"            type="string" value="$(arg frame_id)"/>
     <param name="inverted"            type="bool"   value="$(arg inverted)"/>
     <param name="angle_compensate"    type="bool"   value="$(arg angle_compensate)"/>
+    <param name="diag_time_window"    type="int"    value="$(arg diag_time_window)"/>
     <remap from="scan" to="$(arg topic_name)"/>
   </node>
 </launch>

--- a/launch/rplidar_nodelet.launch
+++ b/launch/rplidar_nodelet.launch
@@ -5,6 +5,7 @@
   <arg name="inverted"          default="false"/>
   <arg name="angle_compensate"  default="true"/>
   <arg name="topic_name"        default="scan"/>
+  <arg name="diag_time_window"  default="30"/>
 
   <node pkg="nodelet" type="nodelet" name="rplidar_nodelet_manager" args="manager" />
 
@@ -14,6 +15,7 @@
     <param name="frame_id"            type="string" value="$(arg frame_id)"/>
     <param name="inverted"            type="bool"   value="$(arg inverted)"/>
     <param name="angle_compensate"    type="bool"   value="$(arg angle_compensate)"/>
+    <param name="diag_time_window"    type="int"    value="$(arg diag_time_window)"/>
     <remap from="scan" to="$(arg topic_name)"/>
   </node>
 

--- a/launch/view_rplidar.launch
+++ b/launch/view_rplidar.launch
@@ -1,6 +1,6 @@
 <!--
-  Used for visualising rplidar in action.  
-  
+  Used for visualising rplidar in action.
+
   It requires rplidar.launch.
  -->
 <launch>
@@ -9,13 +9,15 @@
   <arg name="frame_id"          default="laser"/>
   <arg name="inverted"          default="false"/>
   <arg name="angle_compensate"  default="true"/>
-  
+  <arg name="diag_time_window"  default="30"/>
+
   <include file="$(find rplidar_ros)/launch/rplidar.launch">
-    <arg name="serial_port"       value="$(arg serial_port)"/>  
+    <arg name="serial_port"       value="$(arg serial_port)"/>
     <arg name="serial_baudrate"   value="$(arg serial_baudrate)"/>
     <arg name="frame_id"          value="$(arg frame_id)"/>
     <arg name="inverted"          value="$(arg inverted)"/>
     <arg name="angle_compensate"  value="$(arg angle_compensate)"/>
+    <arg name="diag_time_window"  value="$(arg diag_time_window)"/>
   </include>
 
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find rplidar_ros)/rviz/rplidar.rviz" />

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,8 @@
   <build_depend>nodelet</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>message_filters</build_depend>
+  <build_depend>diagnostic_msgs</build_depend>
+  <build_depend>diagnostic_updater</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rosconsole</run_depend>
@@ -24,6 +26,8 @@
   <run_depend>nodelet</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>message_filters</run_depend>
+  <run_depend>diagnostic_msgs</run_depend>
+  <run_depend>diagnostic_updater</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/plugins/nodelet_plugins.xml" />


### PR DESCRIPTION
Adds diagnostic messages to RPLidar Driver.

The KeyValue pair contains counter for how many times driver has encountered failure, timeout and bad health status along with elapsed time since node started.
